### PR TITLE
Empty RECORD fields as BOOLEAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,34 @@ message Baz {
 `protoc --bq-schema_out=. foo.proto` will generate a file named `foo/bar_table.schema`.
 The message `foo.Baz` is ignored because it doesn't have option `gen_bq_schema.bigquery_opts`.
 
+## Special Case - OneOf Repeated fields of type Empty Message
+
+Take the following example:
+
+```proto
+message PartnerPositionApplicationRequiresReviewEvent {
+  option (gen_bq_schema.bigquery_opts).table_name = "partner_position_application_requires_review";
+
+  string application_id = 1;
+  repeated ApplicationReviewReason reasons = 2;
+}
+
+message ApplicationReviewReason {
+  oneof reason {
+    ReasonAddressMatch address_match = 1;
+    ReasonHasCriminalRecord has_criminal_record = 2;
+  }
+}
+
+message ReasonAddressMatch {
+  repeated string address_partner_ids = 1;
+}
+
+message ReasonHasCriminalRecord {}
+```
+
+The reason `has_criminal_record` is message type `ReasonHasCriminalRecord` which has no fields. In this instance the message is used like a boolean. Rather than discard this field in the BigQuery schema, a field of type `BOOLEAN` is created instead.
+
 ## License
 
 protoc-gen-bq-schema is licensed under the Apache License version 2.0.

--- a/main.go
+++ b/main.go
@@ -281,8 +281,15 @@ func convertField(curPkg *ProtoPackage, desc *descriptor.FieldDescriptorProto, m
 		return nil, err
 	}
 
-	if len(field.Fields) == 0 { // discard RECORDs that would have zero fields
-		return nil, nil
+	// Convert zero field RECORDS to a single boolean where the presence of
+	// the message is interpreted as true. This only really applies in limited
+	// use-cases e.g. where a oneOf value of empty message is used like a bool
+	if len(field.Fields) == 0 {
+		return &Field{
+			Name: desc.GetName(),
+			Type: "BOOLEAN",
+			Mode: "NULLABLE",
+		}, nil
 	}
 
 	return field, nil

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -305,6 +305,9 @@ func TestTypes(t *testing.T) {
 						{ "name": "i2", "type": "INTEGER", "mode": "NULLABLE" },
 						{ "name": "i3", "type": "INTEGER", "mode": "NULLABLE" }
 					]
+				},
+				{
+					"name": "msg2", "type": "BOOLEAN", "mode": "NULLABLE"
 				}
 			]`,
 		})


### PR DESCRIPTION
protoc-gen-bq-schema currently discards repeated fields which have no elements. Example: [https://github.com/utilitywarehouse/partner-mono/blob/master/proto/partner/application/v1/application.proto#L46](Application Requires Review reasons).

This change will instead generated a BOOLEAN type field rather than discarding the repeated field altogether.
